### PR TITLE
Feat/l1 tx hash

### DIFF
--- a/packages/processor/src/service/claim.service.ts
+++ b/packages/processor/src/service/claim.service.ts
@@ -23,7 +23,7 @@ export const processClaimGroup = async (requestingClaims: RequestingClaim[]) => 
   const claimWrappedProof = await generateClaimWrappedProof(claimProofs, walletClientData);
   const claimGnarkProof = await generateClaimGnarkProof(claimWrappedProof);
 
-  await submitClaimProofToScroll(walletClientData, claimProofs, claimGnarkProof);
+  return submitClaimProofToScroll(walletClientData, claimProofs, claimGnarkProof);
 };
 
 const fetchClaimsWithProofs = async (requestingClaims: RequestingClaim[]) => {
@@ -65,5 +65,6 @@ const submitClaimProofToScroll = async (
     proof: `0x${claimGnarkProof.proof}`,
   };
 
-  await submitClaimProof(walletClientData, params);
+  const receipt = await submitClaimProof(walletClientData, params);
+  return receipt.hash
 };

--- a/packages/processor/src/service/job.service.ts
+++ b/packages/processor/src/service/job.service.ts
@@ -30,12 +30,13 @@ const performJob = async (data: QueueJobData): Promise<void> => {
       status: ClaimGroupStatus.PROCESSING,
     });
 
-    await processClaimGroup(group.requestingClaims);
+    const txHash = await processClaimGroup(group.requestingClaims);
 
     await withdrawalDB
       .update(claimSchema)
       .set({
         status: "verified",
+        submitClaimProofTxHash: txHash,
       })
       .where(
         inArray(

--- a/packages/shared/src/db/withdrawalSchema.ts
+++ b/packages/shared/src/db/withdrawalSchema.ts
@@ -42,6 +42,7 @@ export const claimSchema = table(
     withdrawalHash: t.char("withdrawal_hash", { length: 66 }),
     contractWithdrawal: t.jsonb("contract_withdrawal"),
     l1TxHash: t.varchar("l1_tx_hash", { length: 66 }),
+    submitClaimProofTxHash: t.varchar("submit_claim_proof_tx_hash", { length: 66 }),
     createdAt: t.timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [t.index("idx_withdrawals_withdrawal_hash").on(table.withdrawalHash)],


### PR DESCRIPTION
This pull request introduces the following changes:

Schema Update:

Added a new field, [submitClaimProofTxHash](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html), to the [claimSchema](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) in the database. This field stores the transaction hash for the claim proof submission.
Job Processing Logic:

Updated the job processing service to set the [submitClaimProofTxHash](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) field when updating claim status to "verified" after processing a claim group.
These changes improve traceability of claim proof submissions by recording the transaction hash in the database and ensure the processing logic updates this field accordingly.